### PR TITLE
docs: add CONTRIBUTING and SECURITY policy, fix CODE_OF_CONDUCT

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -60,7 +60,8 @@ representative at an online or offline event.
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
 reported to the community leaders responsible for enforcement at
-.
+[GitHub Issues](https://github.com/ahmad9059/HyprFlux/issues).
+
 All complaints will be reviewed and investigated promptly and fairly.
 
 All community leaders are obligated to respect the privacy and security of the

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,156 @@
+# Contributing to HyprFlux
+
+Thank you for your interest in contributing to HyprFlux! This document provides guidelines and instructions for contributing to the project.
+
+## About HyprFlux
+
+HyprFlux is an MIT-licensed, OSI-approved free and open source software project. It is a complete Arch Linux desktop operating system built around Hyprland, featuring a live ISO, installer, boot experience, login flow, theming, tooling, and a maintained desktop environment.
+
+## Ways to Contribute
+
+### Reporting Bugs
+
+If you encounter a bug, please [open an issue](https://github.com/ahmad9059/HyprFlux/issues) with:
+
+- A clear, descriptive title
+- Steps to reproduce the issue
+- Expected behavior vs actual behavior
+- System information (Arch Linux version, Hyprland version, hardware details)
+- Relevant logs and screenshots
+- The version of HyprFlux you're using
+
+### Suggesting Enhancements
+
+Feature requests are welcome! Please [open an issue](https://github.com/ahmad9059/HyprFlux/issues) with:
+
+- A clear description of the feature
+- Why it would benefit HyprFlux users
+- Any implementation ideas or references
+
+### Pull Requests
+
+We welcome pull requests! Please follow these steps:
+
+1. **Fork the repository** and create your branch from `main`
+2. **Make your changes** following our coding standards
+3. **Test your changes** thoroughly on an Arch Linux system
+4. **Update documentation** if applicable
+5. **Submit a pull request** with a clear description
+
+## Development Setup
+
+### Prerequisites
+
+- Arch Linux installation
+- Basic tools: `git`, `curl`, `sudo`
+- Familiarity with shell scripting, Hyprland, and related tools
+
+### Getting Started
+
+```bash
+# Clone your fork
+git clone https://github.com/YOUR_USERNAME/HyprFlux.git
+cd HyprFlux
+
+# Create a branch for your changes
+git checkout -b feature/your-feature-name
+```
+
+### Project Structure
+
+```text
+HyprFlux/
+├── config/          # Project configuration
+├── dotsSetup.sh     # Modular platform setup entrypoint
+├── install.sh       # Primary install entrypoint
+├── lib/             # Shared install helpers
+├── modules/         # Modular setup steps
+├── scripts/         # Installer helper scripts
+├── utilities/       # Themes, archives, logos, cursors
+└── .config/         # Desktop environment files
+    ├── hypr/        # Hyprland configs
+    ├── waybar/      # Waybar configs
+    └── rofi/        # Rofi configs
+```
+
+## Coding Standards
+
+### Shell Scripts
+
+- Use `shellcheck` to validate your scripts
+- Follow [Google's Shell Style Guide](https://google.github.io/styleguide/shellguide.html)
+- Include error handling and meaningful output messages
+- Ensure scripts are idempotent where possible
+
+### Configuration Files
+
+- Maintain consistency with existing configuration style
+- Comment complex configurations
+- Use meaningful variable names
+
+### Commit Messages
+
+- Use present tense ("Add feature" not "Added feature")
+- Use imperative mood ("Move cursor to..." not "Moves cursor to...")
+- Limit the first line to 72 characters
+- Reference issues and pull requests when applicable
+
+Example:
+```
+Add Plymouth theme configuration module
+
+- Create modules/plymouth/setup.sh
+- Update dotsSetup.sh to include Plymouth module
+- Add documentation in README.md
+
+Fixes #123
+```
+
+## Testing
+
+Before submitting a pull request:
+
+1. Test your changes on a fresh Arch Linux installation or VM
+2. Verify the installer completes successfully
+3. Check that desktop components load correctly
+4. Ensure no regressions in existing functionality
+
+### Testing with QEMU
+
+```bash
+# Build and test ISO changes
+cd references/Hyprflux-ISO
+./build.sh
+qemu-system-x86_64 -cdrom output/hyprflux.iso -m 4096
+```
+
+## Areas for Contribution
+
+- **Installer improvements**: reliability, hardware support, edge cases
+- **Documentation**: guides, troubleshooting, translations
+- **Theming**: GTK themes, icon packs, wallpapers
+- **Desktop workflows**: keybinds, scripts, automation
+- **ISO development**: boot experience, TUI refinements
+- **Bug fixes**: stability, compatibility, performance
+
+## Review Process
+
+1. Maintainers will review your pull request
+2. Feedback may be provided for changes
+3. Once approved, your PR will be merged
+
+## Code of Conduct
+
+This project follows the [Contributor Covenant Code of Conduct](CODE_OF_CONDUCT.md). By participating, you are expected to uphold this code.
+
+## License
+
+By contributing to HyprFlux, you agree that your contributions will be licensed under the [MIT License](LICENSE).
+
+## Questions?
+
+Feel free to [open an issue](https://github.com/ahmad9059/HyprFlux/issues) for questions or discussions about the project.
+
+---
+
+Thank you for contributing to HyprFlux!

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,100 @@
+# Security Policy
+
+## Supported Versions
+
+HyprFlux is actively developed. Security updates are applied to the latest release.
+
+| Version | Supported |
+| ------- | --------- |
+| main    | Yes       |
+| older   | No        |
+
+## Reporting a Vulnerability
+
+We take security seriously. If you discover a security vulnerability, please report it responsibly.
+
+### How to Report
+
+**Do not** open a public GitHub issue for security vulnerabilities.
+
+Instead, please:
+
+1. Go to [GitHub Security Advisories](https://github.com/ahmad9059/HyprFlux/security/advisories)
+2. Click "Report a vulnerability"
+3. Provide a detailed description of the vulnerability
+
+Or email the maintainer directly via GitHub: `ahmad9059`
+
+### What to Include
+
+Please provide:
+
+- A description of the vulnerability
+- Steps to reproduce
+- Affected components
+- Potential impact
+- Suggested fix (if any)
+
+### Response Timeline
+
+- **Initial response**: Within 48 hours
+- **Triage and assessment**: Within 1 week
+- **Fix development**: Depends on severity and complexity
+- **Disclosure**: After fix is released
+
+## Security Considerations
+
+### Installer Scripts
+
+HyprFlux runs installation scripts with elevated privileges. We recommend:
+
+- Reviewing scripts before running: `curl -fsSL https://hyprflux.dev/install | less`
+- Running on fresh systems or VMs for testing
+- Backing up existing configurations
+
+### Trust Model
+
+HyprFlux installs software from:
+
+- Official Arch Linux repositories
+- Arch User Repository (AUR)
+- HyprFlux repository (for configurations and theming)
+
+Review all package sources and configurations to ensure they meet your security requirements.
+
+### System Access
+
+HyprFlux configures:
+
+- User-level configurations in `~/.config/`
+- System-level configurations via `sudo`
+- Login/display manager settings (SDDM)
+- Boot loader settings (GRUB)
+
+## Known Security Notes
+
+- **Root/sudo access**: The installer requires sudo for system-level configurations
+- **AUR packages**: Some packages come from the AUR which are not officially vetted by Arch Linux
+- **Configuration backups**: Previous configs are backed up to `~/dotfiles_backup/`
+
+## Disclosure Policy
+
+We follow responsible disclosure:
+
+1. Vulnerability is reported privately
+2. Maintainers investigate and develop a fix
+3. Fix is released
+4. Security advisory is published
+5. Credit is given to the reporter (if desired)
+
+## Security Updates
+
+Security updates will be announced via:
+
+- GitHub Releases
+- GitHub Security Advisories
+- Project repository
+
+---
+
+Thank you for helping keep HyprFlux secure!


### PR DESCRIPTION
## Summary

- Add `CONTRIBUTING.md` with contribution guidelines, development setup, coding standards, and review process
- Add `SECURITY.md` with security policy, vulnerability reporting instructions, and trust model documentation  
- Fix `CODE_OF_CONDUCT.md` enforcement contact (wasempty, now links to GitHub Issues)

## Changes

### CONTRIBUTING.md
- Project overview (MIT-licensed, OSI-approved FOSS)
- Bug reporting and feature request guidelines
- Pull request workflow
- Development setup instructions
- Project structure documentation
- Coding standards for shell scripts and configs
- Commit message guidelines
- Testing instructions (including QEMU)
- Areas for contribution

### SECURITY.md
- Supported versions policy
- Vulnerability reporting process (GitHub Security Advisories)
- Response timeline
- Security considerations (installer scripts, trust model, system access)
- Known security notes
- Responsible disclosure policy

### CODE_OF_CONDUCT.md
- Fixed missing enforcement contact URL

## Notes

HyprFlux is an MIT-licensed, OSI-approved open source project. These documents establish proper governance and community guidelines.