### PR TITLE
Updated hyprland config syntax to v0.55

### DIFF
--- a/.config/hypr/UserConfigs/UserSettings.conf
+++ b/.config/hypr/UserConfigs/UserSettings.conf
@@ -8,7 +8,7 @@
 # NOTE: some settings are in ~/.config/hypr/UserConfigs/UserDecorAnimations.conf
 
 dwindle {
-  pseudotile = true
+  #pseudotile = true
   preserve_split = true
   #smart_split = true
   special_scale_factor = 1
@@ -77,7 +77,6 @@ gestures {
 misc {
   disable_hyprland_logo = true
   disable_splash_rendering = true
-  vfr = true
   vrr = 2
   mouse_move_enables_dpms = true
   enable_swallow = off
@@ -115,4 +114,8 @@ cursor {
   enable_hyprcursor = true
   warp_on_change_workspace = 2
   no_warps = true 
+}
+
+debug {
+  vfr = true
 }

--- a/.config/hypr/configs/Keybinds.conf
+++ b/.config/hypr/configs/Keybinds.conf
@@ -24,7 +24,7 @@ bind = $mainMod, K, layoutmsg, cycleprev
 bind = $mainMod CTRL, Return, layoutmsg, swapwithmaster
 
 # Dwindle Layout
-bind = $mainMod SHIFT, I, togglesplit # only works on dwindle layout
+bind = $mainMod SHIFT, I, layoutmsg, rotatesplit # only works on dwindle layout
 bind = $mainMod, P, pseudo, # dwindle
 
 # Works on either layout (Master or Dwindle)


### PR DESCRIPTION
# Hyprland 0.55 compatibility fixes

v0.55 introduced breaking changes to the legacy parser:
- togglesplit is now a layoutmsg (rotatesplit)
- pseudotile was removed from dwindle options
- vfr was moved to the debug category